### PR TITLE
Added support for ufmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+## [0.2.1] - 2024-10-26
+* Added support for `ufmt`
+
 ## [0.2.0]  - 2024-10-19
 * Added support for 40x4 character displays using two HD44780 controllers with a PCF8574T I2C adapter wired with two enable pins, one for each controller.
 * Improved unit tests
@@ -9,5 +12,6 @@
 ## 0.1.0
 Initial release. Support for both Generic PCF8574T I2C and Adafruit Backpack character display adapters.
 
-[Unreleased]: https://github.com/michaelkamprath/bespokeasm/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/michaelkamprath/bespokeasm/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/michaelkamprath/bespokeasm/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/michaelkamprath/bespokeasm/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [0.2.1] - 2024-10-26
 * Added support for `ufmt`
+* Added `display_type()` method to `BaseCharacterDisplay` to allow for querying the display type
+* Improved documentation
 
 ## [0.2.0]  - 2024-10-19
 * Added support for 40x4 character displays using two HD44780 controllers with a PCF8574T I2C adapter wired with two enable pins, one for each controller.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "i2c-character-display"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "Driver for HD44780-based character displays connected via a I2C adapter"
 license = "MIT"
@@ -21,9 +21,12 @@ doctest = false
 embedded-hal = { version = "1.0" }
 bitfield = "0.17"
 defmt = { version = "0.3", optional = true }
+ufmt = {version = "0.2", optional = true}
+
 
 [features]
 defmt = ["dep:defmt", "embedded-hal/defmt-03"]
+ufmt = ["dep:ufmt"]
 
 [dev-dependencies]
 embedded-hal-mock = "0.11"

--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@ compatible character display with an "I2C backpack" interface in an embedded, `n
 are supported:
 
 - **[Adafruit I2C/SPI LCD Backpack](https://www.adafruit.com/product/292)** - This is a simple I2C backpack that can be used with either I2C
-or SPI. It is available from Adafruit and other retailers. This library only supports the I2C interface.
+  or SPI. It is available from Adafruit and other retailers. This library only supports the I2C interface.
 - **PCF8574-based I2C adapter** - These adapters are ubiquitous on eBay and AliExpress and have no clear branding. The most common pin
-wiring uses 4 data pins and 3 control pins. Most models have the display 4-bit data pins connected to P4-P7 of the PCF8574. This library
-supports that configuration, though it would be straightforward to add support for other configurations.
+  wiring uses 4 data pins and 3 control pins. Most models have the display 4-bit data pins connected to P4-P7 of the PCF8574. This library
+  supports that configuration, though it would be straightforward to add support for other configurations.
 
 Key features include:
 - Convenient high-level API for controlling the display
@@ -67,6 +67,13 @@ use core::fmt::Write;
 
 write!(lcd, "Hello, world!")?;
 ```
+The optional `ufmt` feature enables the `ufmt` crate, which allows the `uwriteln!` and `uwrite!` macros to be used with the display:
+```rust
+use ufmt::uwriteln;
+
+uwriteln!(lcd, "Hello, world!")?;
+```
+
 The various methods for controlling the LCD are also available. Each returns a `Result` that wraps the display object in `Ok()`, allowing for easy chaining
 of commands. For example:
 ```rust

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 <!-- cargo-sync-readme start -->
 
 This Rust `embedded-hal`-based library is a simple way to control a [HD44780](https://en.wikipedia.org/wiki/Hitachi_HD44780_LCD_controller)
-compatible character display with an "I2C backpack" interface in an embedded, `no_std` environment. A number of I2C backpack interfaces
+compatible character display with an "I2C backpack" interface in an embedded, `no_std` environment. A number of I2C adapter interfaces
 are supported:
 
 - **[Adafruit I2C/SPI LCD Backpack](https://www.adafruit.com/product/292)** - This is a simple I2C backpack that can be used with either I2C
   or SPI. It is available from Adafruit and other retailers. This library only supports the I2C interface.
-- **PCF8574-based I2C adapter** - These adapters are ubiquitous on eBay and AliExpress and have no clear branding. The most common pin
-  wiring uses 4 data pins and 3 control pins. Most models have the display 4-bit data pins connected to P4-P7 of the PCF8574. This library
-  supports that configuration, though it would be straightforward to add support for other configurations.
+- **PCF8574-based I2C adapter** - These adapters are ubiquitous on eBay and AliExpress and have no clear branding. Furthermore, some character
+  display makers, such as [Surenoo](https://www.surenoo.com), integrate a PCF8574T directly on the display board enabling I2C connections without a seperate adapter.
+  The most common pin wiring uses 4 data pins and 3 control pins. Most models have the display 4-bit data pins connected to P4-P7 of the PCF8574.
+  This library supports that configuration, though it would be straightforward to add support for other configurations.
 
 Key features include:
 - Convenient high-level API for controlling the display
@@ -18,7 +19,7 @@ Key features include:
 - Backlight control
 - `core::fmt::Write` implementation for easy use with the `write!` macro
 - Compatible with the `embedded-hal` traits v1.0 and later
-- Support for character displays that used multiple HD44780 drivers, such as the 40x4 display
+- Support for character displays that uses multiple HD44780 drivers, such as the 40x4 display
 
 ## Usage
 Add this to your `Cargo.toml`:
@@ -27,7 +28,9 @@ Add this to your `Cargo.toml`:
 i2c-character-display = { version = "0.1", features = ["defmt"] }
 ```
 The `features = ["defmt"]` line is optional and enables the `defmt` feature, which allows the library's errors to be used with the `defmt` logging
-framework. Then select the appropriate adapter for your display:
+framework. Another optional feature is `features = ["ufmt"]`, which enables the `ufmt` feature, allowing the `uwriteln!` and `uwrite!` macros to be used.
+
+Then select the appropriate adapter for your display:
 ```rust
 use i2c_character_display::{AdafruitLCDBackpack, CharacterDisplayPCF8574T, LcdDisplayType};
 use embedded_hal::delay::DelayMs;
@@ -44,7 +47,7 @@ let delay = ...; // DelayMs implementation
 let mut lcd = AdafruitLCDBackpack::new(i2c, LcdDisplayType::Lcd16x2, delay);
 // PCF8574T adapter
 let mut lcd = CharacterDisplayPCF8574T::new(i2c, LcdDisplayType::Lcd16x2, delay);
-// Character display with dual HD44780 drivers using a PCF8574T I2C adapter
+// Character display with dual HD44780 drivers using a single PCF8574T I2C adapter
 let mut lcd = CharacterDisplayDualHD44780::new(i2c, LcdDisplayType::Lcd40x4, delay);
 ```
 When creating the display object, you can choose the display type from the `LcdDisplayType` enum. The display type should match the physical
@@ -79,6 +82,11 @@ of commands. For example:
 ```rust
 lcd.backlight(true)?.clear()?.home()?.print("Hello, world!")?;
 ```
+### Multiple HD44780 controller character displays
+Some character displays, such as the 40x4 display, use two HD44780 controllers to drive the display. This library supports these displays by
+treating them as one logical display with multiple HD44780 controllers. The `CharacterDisplayDualHD44780` type is used to control these displays.
+Use the various methods to control the display as you would with a single HD44780 controller display. The `set_cursor` method sets the active HD44780
+conmtroller device based on the row number you select.
 
 
 <!-- cargo-sync-readme end -->

--- a/src/adapter_config.rs
+++ b/src/adapter_config.rs
@@ -24,8 +24,8 @@ impl defmt::Format for AdapterError {
 impl ufmt::uDisplay for AdapterError {
     fn fmt<W>(&self, w: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
     where
-        W: ufmt::uWrite + ?Sized
-{
+        W: ufmt::uWrite + ?Sized,
+    {
         match self {
             AdapterError::BadDeviceId => ufmt::uwrite!(w, "BadDeviceId"),
         }

--- a/src/adapter_config.rs
+++ b/src/adapter_config.rs
@@ -20,6 +20,18 @@ impl defmt::Format for AdapterError {
     }
 }
 
+#[cfg(feature = "ufmt")]
+impl ufmt::uDisplay for AdapterError {
+    fn fmt<W>(&self, w: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
+    where
+        W: ufmt::uWrite + ?Sized
+{
+        match self {
+            AdapterError::BadDeviceId => ufmt::uwrite!(w, "BadDeviceId"),
+        }
+    }
+}
+
 pub trait AdapterConfigTrait<I2C>: Default
 where
     I2C: i2c::I2c,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ where
 {
     fn fmt<W>(&self, w: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
     where
-        W: ufmt::uWrite + ?Sized
+        W: ufmt::uWrite + ?Sized,
     {
         match self {
             Error::I2cError(_e) => ufmt::uwrite!(w, "I2C error"),
@@ -220,7 +220,7 @@ pub enum LcdDisplayType {
 impl ufmt::uDisplay for LcdDisplayType {
     fn fmt<W>(&self, w: &mut ufmt::Formatter<'_, W>) -> Result<(), W::Error>
     where
-        W: ufmt::uWrite + ?Sized
+        W: ufmt::uWrite + ?Sized,
     {
         match self {
             LcdDisplayType::Lcd20x4 => ufmt::uwrite!(w, "20x4"),
@@ -708,7 +708,6 @@ where
         Ok(())
     }
 }
-
 
 #[cfg(feature = "ufmt")]
 /// Implement the `ufmt::uWrite` trait for the LCD backpack, allowing it to be used with the `uwriteln!` and `uwrite!` macros.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,6 +414,11 @@ where
         &mut self.i2c
     }
 
+    /// returns the `LcdDisplayType` used to create the display
+    pub fn display_type(&self) -> LcdDisplayType {
+        self.lcd_type
+    }
+
     /// Sends a command datum to the display. Normally users do not need to call this directly.
     /// For multiple devices, this sends the command to the currently active contoller device.
     fn send_command(&mut self, command: u8) -> Result<(), Error<I2C>> {
@@ -897,6 +902,7 @@ mod lib_tests {
         let mut lcd = AdafruitLCDBackpack::new(i2c, LcdDisplayType::Lcd16x2, NoopDelay::new());
         let result = lcd.init();
         assert!(result.is_ok());
+        assert!(lcd.display_type() == LcdDisplayType::Lcd16x2);
 
         // finish the i2c mock
         lcd.i2c().done();
@@ -1004,6 +1010,7 @@ mod lib_tests {
             CharacterDisplayDualHD44780::new(i2c, LcdDisplayType::Lcd40x4, NoopDelay::new());
         let result = lcd.init();
         assert!(result.is_ok());
+        assert!(lcd.display_type() == LcdDisplayType::Lcd40x4);
 
         // finish the i2c mock
         lcd.i2c().done();


### PR DESCRIPTION
Added optional feature enabling support for [`ufmt`](https://github.com/japaric/ufmt/). Also improvements to unit tests, documentation, and `defmt` support.