### PR TITLE
Fix timing issues in initialization sequence

### DIFF
--- a/src/driver/hd44780/adapter.rs
+++ b/src/driver/hd44780/adapter.rs
@@ -51,7 +51,9 @@ where
             self.send_command_to_controller(controller, LCD_CMD_DISPLAYCONTROL | display_control)?;
             self.send_command_to_controller(controller, LCD_CMD_ENTRYMODESET | display_mode)?;
             self.send_command_to_controller(controller, LCD_CMD_CLEARDISPLAY)?;
+            self.device_config().delay.delay_ms(2);
             self.send_command_to_controller(controller, LCD_CMD_RETURNHOME)?;
+            self.device_config().delay.delay_ms(2);
         }
         // set up the display
         self.set_backlight(true)?;

--- a/src/driver/hd44780/adapter.rs
+++ b/src/driver/hd44780/adapter.rs
@@ -145,8 +145,10 @@ where
         self.set_rs(rs_setting);
         self.set_rw(false);
 
-        // now write the low nibble
         self.set_data(value & 0x0F);
+        // first write value without the enable strobe
+        // to ensure that the address set-up time t_AS = 40 ns is observed
+        self.write_bits_to_gpio()?;
         self.set_enable(true, controller)?;
         self.write_bits_to_gpio()?;
         self.set_enable(false, controller)?;


### PR DESCRIPTION
Due to the particular example used by the documentation of the HAL I'm using, I first tried using this library with an I²C clock of 50 kHz (I'm using an adapter based on a PCF8574). Although I didn't know the cause at the time, this was preventing my LCD from working. I eventually perturbed it into working by switching to 100 kHz, but the mystery was getting to me – why would a *slower* I²C clock break things?

After some experiments, things got weirder – if I inserted some delay into `write_bits_to_gpio`, making things even slower, it started working again!

The mystery was getting to me, and eventually, I narrowed it down to the init sequence, and how it doesn't wait for the CLEAR and HOME commands to finish executing. I believe that for a 100 kHz I²C clock, things just happened to align in such a way, that one of these commands would get skipped completely. Slowing things down made it catch some of the writes again, which probably misaligned the phase of the 4-bit-wide bus – and slowing things down even more made everything work as written in the code.

While I'm at it, I'm also including a fix to make sure that the address set up time is observed – see t_AS on the figure below, which Hitachi have helpfully buried at the very end of the datasheet:

<img width="751" height="504" alt="image" src="https://github.com/user-attachments/assets/5a445f7a-9f7a-43a4-9c66-2285eeb786d6" />

Admittedly, I couldn't find an experimental setup in which this particular issue prevented my LCD from working – but complying with the spec is always a good idea ;3